### PR TITLE
Update plugin path in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: fish-shop/install-plugin@v2
         with:
           plugin-manager: ${{ matrix.plugin-manager }}
-          plugins: (pwd)
+          plugins: ${{ github.workspace }}
 
       - name: Check plugin is installed
         run: functions -q extract x


### PR DESCRIPTION
Hi @shoriminimoe 👋🏻, a recent change to the [fish-shop/install-plugin](https://github.com/fish-shop/install-plugin) action has introduced a breaking change in specific situations:

To mitigate the potential for arbitrary code injection, the `plugins` input is now escaped internally after being read from an intermediate environment variable. This means that `fish` command substitutions (such as `(pwd)`) are no longer evaluated. Instead, the string is passed in its literal form the plugin manager, which may result in failures when installing custom GitHub Actions such as `fish-extract`[^1]. For example:

```shell
fisher: Invalid plugin name or host unavailable: "(pwd)"
```

The breaking change was introduced in [v2.3.0](https://github.com/fish-shop/install-plugin/releases/tag/v2.3.0) but not identified as such at that point in time. This pull request introduces a fix that should resolve the breakage and an example successful CI workflow using these changes can be viewed in a forked version of the `fish-extract` project [here](https://github.com/marcransome/fish-extract/actions/runs/10322359932).

[^1]: See the [failing CI workflow run](https://github.com/marcransome/fish-extract/actions/runs/10322312395) in a forked version of the `fish-extract` project.