### PR TITLE
feat(x): add --wraps and description to x alias

### DIFF
--- a/functions/x.fish
+++ b/functions/x.fish
@@ -1,4 +1,4 @@
 # alias of extract from fish-extract plugin
-function x
+function x --wraps extract -d "Alias of extract"
     extract $argv
 end


### PR DESCRIPTION
## Summary
- `--wraps extract` so fish reuses `extract`'s tab-completions for `x`.
- `-d "Alias of extract"` so the alias is self-describing in `type`/`funced`.

## Test Plan
- `fish -n functions/x.fish` passes; install-plugin CI job verifies `functions -q x`.

https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs

---
_Generated by [Claude Code](https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs)_