### PR TITLE
ci: bump checkout to v4, add permissions, disable fail-fast

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,24 +8,28 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: fish-actions/install-fish@v1
       - uses: fish-shop/syntax-check@v1
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: fish-actions/install-fish@v1
       - uses: melusina-org/setup-macports@v1
         if: matrix.os == 'macos-latest'
@@ -37,6 +41,7 @@ jobs:
 
   install:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         plugin-manager: [fisher, oh-my-fish]


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` from v3 to v4 in the `lint` and `test` jobs (the `install` job was already on v4).
- Add a top-level `permissions: contents: read` block per GitHub's recommended workflow hardening.
- Set `fail-fast: false` on the `test` and `install` matrices so a failure on one OS / plugin-manager combo doesn't cancel the others.

## Test Plan

- [x] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yaml'))"`).
- [x] CI itself is the test — green runs on this PR confirm the workflow is still valid.

https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs

---
_Generated by [Claude Code](https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs)_