### PR TITLE
ci(deps): verify SHA256 of the 7zip download

### DIFF
--- a/tests/install-dependencies.sh
+++ b/tests/install-dependencies.sh
@@ -20,7 +20,10 @@ install_linux() {
 		zstd
 
 	tmpdir=$(mktemp -d)
-	wget -O "$tmpdir/7zip.tar.xz" https://www.7-zip.org/a/7z2405-linux-x64.tar.xz
+	sevenzip_url="https://www.7-zip.org/a/7z2405-linux-x64.tar.xz"
+	sevenzip_sha256="8a5bdf9360113764e9df19f433c15097f364924d624ff9c098848f6d0d35bf9f"
+	wget -O "$tmpdir/7zip.tar.xz" "$sevenzip_url"
+	echo "$sevenzip_sha256  $tmpdir/7zip.tar.xz" | sha256sum -c -
 	tar xf "$tmpdir/7zip.tar.xz" -C "$tmpdir"
 	sudo mv -t /usr/local/bin/ "$tmpdir/7zz"
 }


### PR DESCRIPTION
## Summary

- Pins the expected SHA256 digest (`8a5bdf9360113764e9df19f433c15097f364924d624ff9c098848f6d0d35bf9f`) of the 7-zip Linux tarball downloaded by `tests/install-dependencies.sh`.
- Runs `sha256sum -c` after the `wget` so a compromised mirror or MITM cannot substitute a malicious `7zz` binary on CI.
- Digest is held in a local variable so future updates are a one-line change.

## Test Plan

- [x] `bash -n tests/install-dependencies.sh` parses cleanly.
- [ ] CI Linux test job downloads and verifies the tarball on next run.

https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs

---
_Generated by [Claude Code](https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs)_