### PR TITLE
docs(readme): add CI badge, mention x alias, add Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fish-extract
 
+[![CI](https://github.com/shoriminimoe/fish-extract/actions/workflows/ci.yaml/badge.svg)](https://github.com/shoriminimoe/fish-extract/actions/workflows/ci.yaml)
+
 An archive extraction plugin for
 [fish-shell](https://github.com/fish-shell/fish-shell). Inspired by the
 [oh-my-zsh extract plugin](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/extract).
@@ -29,6 +31,23 @@ curl https://raw.githubusercontent.com/shoriminimoe/fish-extract/main/functions/
 
 ```sh
 extract FILE [FILE ...]
+```
+
+The `x` alias is also installed; `x FILE [FILE ...]` is equivalent.
+
+## Development
+
+Run the test suite with [fishtape](https://github.com/jorgebucaran/fishtape):
+
+```sh
+bash tests/install-dependencies.sh    # one-time, installs archive tools
+fishtape tests/file-types.fish
+```
+
+[pre-commit](https://pre-commit.com/) hooks (`fish_indent`, `fish_syntax`, `gitlint`) are configured in `.pre-commit-config.yaml`:
+
+```sh
+pre-commit install
 ```
 
 ## Supported Formats


### PR DESCRIPTION
## Summary

- Add a CI status badge under the H1 linking to the `ci.yaml` workflow.
- Document the `x` alias as an equivalent to `extract` under Usage.
- Add a Development section covering fishtape tests (with `tests/install-dependencies.sh`) and pre-commit hook setup.

## Test Plan

- Markdown structure spot-checked; no functional changes.

https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs

---
_Generated by [Claude Code](https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs)_