### PR TITLE
chore: pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: fish_indent
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.17.0
+    rev: v0.19.1
     hooks:
       - id: gitlint
         args: [--contrib=CT1, --ignore=B6, --msg-filename]


### PR DESCRIPTION
## Summary

Ran `pre-commit autoupdate` to refresh stale third-party hook revisions in `.pre-commit-config.yaml`:

- `hugoh/pre-commit-fish`: `v1.2` -> `v1.2` (already at latest per autoupdate)
- `jorisroovers/gitlint`: `v0.17.0` -> `v0.19.1`

The `gitlint` hook id and `args` (`[--contrib=CT1, --ignore=B6, --msg-filename]`) are preserved — they remain compatible with v0.19.1.

## Test Plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.pre-commit-config.yaml'))"` parses cleanly
- [x] `pre-commit autoupdate` produced the bump (canonical source of truth)
- [x] Ran `pre-commit run --all-files`: `gitlint` hook environment installs successfully; `fish_syntax` and `fish_indent` fail only because the `fish` executable is not available in this environment (unrelated to the bump)

https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs

---
_Generated by [Claude Code](https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs)_