### PR TITLE
test: containerize the Linux fishtape job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   lint:
@@ -20,19 +21,29 @@ jobs:
       - uses: fish-actions/install-fish@v1
       - uses: fish-shop/syntax-check@v1
 
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+  test-linux:
+    runs-on: ubuntu-latest
 
-    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: fish-extract-test:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Run fishtape in container
+        run: docker run --rm -v "$PWD":/workspace fish-extract-test:ci -c 'fishtape tests/file-types.fish'
+
+  test-macos:
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
       - uses: fish-actions/install-fish@v1
       - uses: melusina-org/setup-macports@v1
-        if: matrix.os == 'macos-latest'
       - name: Install dependencies
         run: bash tests/install-dependencies.sh
       - uses: fish-shop/run-fishtape-tests@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.7
+FROM ubuntu:24.04
+
+# Pre-install fish, TLS roots, and sudo. Archive tools (and 7zz) are
+# installed below by tests/install-dependencies.sh, so the Linux apt
+# list lives in exactly one place.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        fish \
+        sudo && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY tests/install-dependencies.sh /tmp/install-dependencies.sh
+RUN bash /tmp/install-dependencies.sh && rm /tmp/install-dependencies.sh
+
+# Install fishtape system-wide (vendor_functions.d is auto-loaded by fish for all users).
+ARG FISHTAPE_VERSION=3.0.1
+RUN wget -O /tmp/fishtape.tar.gz "https://github.com/jorgebucaran/fishtape/archive/refs/tags/${FISHTAPE_VERSION}.tar.gz" && \
+    tar xf /tmp/fishtape.tar.gz -C /tmp && \
+    cp /tmp/fishtape-*/functions/fishtape.fish /usr/share/fish/vendor_functions.d/ && \
+    rm -rf /tmp/fishtape.tar.gz /tmp/fishtape-*
+
+WORKDIR /workspace
+ENTRYPOINT ["fish"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,17 @@ The `x` alias is also installed; `x FILE [FILE ...]` is equivalent.
 
 ## Development
 
-Run the test suite with [fishtape](https://github.com/jorgebucaran/fishtape):
+Run the test suite with [fishtape](https://github.com/jorgebucaran/fishtape).
+
+On Linux (or any Docker host) the recommended path is the bundled `Dockerfile`,
+which has every archive tool plus fishtape baked in:
+
+```sh
+docker build -t fish-extract-test .
+docker run --rm -v "$PWD":/workspace fish-extract-test -c 'fishtape tests/file-types.fish'
+```
+
+On macOS, install dependencies natively and run fishtape directly:
 
 ```sh
 bash tests/install-dependencies.sh    # one-time, installs archive tools


### PR DESCRIPTION
## Summary

Move the Linux fishtape test job into a Docker container with all archive tools baked in, so the test setup is reproducible locally and doesn't break when an upstream package source changes.

The Dockerfile invokes `tests/install-dependencies.sh` to install the archive tools — the apt list lives in exactly one place and is shared between the Linux container build and local macOS contributors.

### Files changed

- **`Dockerfile`** (new) — Ubuntu 24.04, pre-installs `fish` + `ca-certificates` + `sudo`, then `COPY`s `tests/install-dependencies.sh` and runs it (which apt-installs every archive tool and downloads `7zz` from the pinned `ip7z/7zip` GitHub release with SHA256 verification). Fishtape `3.0.1` is dropped into `/usr/share/fish/vendor_functions.d/` so it's auto-loaded for any user.
- **`.github/workflows/ci.yaml`** — `test` matrix split into:
  - `test-linux`: `docker/setup-buildx-action@v3` → `docker/build-push-action@v6` (load + GHA cache) → `docker run --rm -v "$PWD":/workspace fish-extract-test:ci -c 'fishtape tests/file-types.fish'`
  - `test-macos`: same native steps as before, no matrix
  - Top-level `permissions:` adds `actions: write` (needed by buildx GHA cache writer).
  - `lint` and `install` jobs untouched.
- **`README.md`** — Development section updated to recommend `docker build` / `docker run` on Linux and keep the native flow on macOS.
- **`tests/install-dependencies.sh`** — unchanged on `main` (restored from earlier draft so the script keeps its `install_linux` branch and the Dockerfile can call it).

## Test Plan

- [x] `bash -n tests/install-dependencies.sh`
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yaml'))"`
- [ ] `test-linux` CI job goes green (sandbox didn't have a docker daemon, so the image build is unverified locally)
- [ ] `test-macos` CI job stays green

https://claude.ai/code/session_014sUVGv2w82SoczUr4jebHs